### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ with DockerHun pull limits.
 | DockerHub       | [sergeykons/statuspage-exporter](https://hub.docker.com/r/sergeykons/statuspage-exporter)                                          |
 
 ```bash
-docker run -p 9747:9747 ghcr.io/sergeyshevch/statuspage-exporter --statuspages=https://www.githubstatus.com, https://https://jira-software.status.atlassian.com
+docker run -p 9747:8080 ghcr.io/sergeyshevch/statuspage-exporter --statuspages=https://www.githubstatus.com, https://https://jira-software.status.atlassian.com
 ```
 
 ### Helm


### PR DESCRIPTION
The project exports port 8080, but in the documentation, it is exporting another port to docker, which is 9747

![image](https://github.com/sergeyshevch/statuspage-exporter/assets/44671356/f955a705-75b2-41d6-a204-ea56ceef7451)
