### PR TITLE
Update statuspage.io fetch function

### DIFF
--- a/pkg/engines/statuspageio/fetch.go
+++ b/pkg/engines/statuspageio/fetch.go
@@ -92,7 +92,7 @@ func FetchStatusPage(
 			result.Page.Name,
 			targetURL,
 			component.Name,
-		).Set(float64(IndicatorToMetricValue(component.Status)))
+		).Set(float64(StatusToMetricValue(component.Status)))
 	}
 
 	overallStatus.WithLabelValues(


### PR DESCRIPTION
Return proper status values for statuspage.io engine. 
Fix https://github.com/sergeyshevch/statuspage-exporter/issues/28

Data coming in from statuspage is `component.Status = "operational"`. It was using the wrong function - `IndicatorToMetricValue`. Changing it to `StatusToMetricValue` returns proper values.